### PR TITLE
Compilation fix

### DIFF
--- a/src/examples/compute_stats.cpp
+++ b/src/examples/compute_stats.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
 	{
 		printf("Usage: %s <sift_file> <groud_truth_match> <match_file>\n", argv[0]);
 		printf("Each line of the ground_truth_match file consists of a 5-tuple of the form <pmatch, fmatch, hmatch, index1, index2>\n");
-		printf("Each line of the match_file conssits of a 2-tuple of the form <index1, index2>\n");
+		printf("Each line of the match_file consists of a 2-tuple of the form <index1, index2>\n");
 		return -1;
 	}
 

--- a/src/examples/euclidean_matrix.cpp
+++ b/src/examples/euclidean_matrix.cpp
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sstream>
 #include <stdio.h>
 #include <cmath>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <Eigen/SVD>
@@ -63,7 +64,7 @@ int main(int argc, char **argv)
 	ss >> matrix_filename;
 	FILE *matrix_file = fopen(matrix_filename.c_str(), "w");
 
-	point2d points[MATRIX_SIZE];
+	std::vector<point2d> points(MATRIX_SIZE);
 	for(int i = 0; i < MATRIX_SIZE; i++)
 	{
 		points[i].x = rand() % 1000;	

--- a/src/examples/image_search.cpp
+++ b/src/examples/image_search.cpp
@@ -36,7 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <vector>
 #include <fstream>
-#include <unistd.h>
+#include <thread>
 
 #include "vot_pipeline.h"
 #include "io_utils.h"
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
     int depth = 6;
     int branch_num = 8;
     int sift_type = 0;
-    int thread_num = sysconf(_SC_NPROCESSORS_ONLN);     // this works on unix and mac
+    int thread_num = std::thread::hardware_concurrency();
     int start_id = 0;
     int num_matches = 100;
 

--- a/src/examples/web_search.cpp
+++ b/src/examples/web_search.cpp
@@ -36,7 +36,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <vector>
 #include <fstream>
-#include <unistd.h>
 
 #include "vocab_tree.h"
 #include "io_utils.h"

--- a/src/image_graph/image_graph.cpp
+++ b/src/image_graph/image_graph.cpp
@@ -112,11 +112,7 @@ void ImageGraph::addEdgeu(const vot::LinkEdge &n)
 
 int ImageGraph::numConnectedComponents(int threshold)
 {
-    bool is_visited[size_];
-    for(int i = 0; i < size_; i++)
-    {
-        is_visited[i] = false;
-    }
+    std::vector<bool> is_visited(size_, false);
 
     size_t numCC = 0;
     for(int i = 0; i < size_; i++)

--- a/src/vocab_tree/clustering.cpp
+++ b/src/vocab_tree/clustering.cpp
@@ -240,8 +240,8 @@ namespace tw
 		}
 		else
 		{
-			double *sub_totals[thread_num];	
-			size_t *sub_counts[thread_num];
+			std::vector<double *>sub_totals(thread_num);
+			std::vector<size_t *>sub_counts(thread_num);
 			for(int i = 0; i < thread_num; i++)
 			{
 				sub_totals[i] = new double [dim * k];

--- a/src/vocab_tree/vocab_tree.cpp
+++ b/src/vocab_tree/vocab_tree.cpp
@@ -289,7 +289,7 @@ namespace vot
             std::vector<std::thread> threads;
             int subtree_threads = thread_num / bf;
             size_t offset = 0;
-            double *sub_means[bf];
+            std::vector<double *>sub_means(bf);
             for(int i = 0; i < bf; i++)
             {
                 int sub_thread_num = 0;

--- a/test/unit_test.cpp
+++ b/test/unit_test.cpp
@@ -3,7 +3,6 @@
 #include <string>
 #include <vector>
 #include <fstream>
-#include <unistd.h>
 
 #include "../src/vocab_tree/vot_pipeline.h"
 #include "gtest/gtest.h"


### PR DESCRIPTION
- More portable vector allocation.
  - i.e. Visual studio does not allow [value] if value is not a const variable.

- use std::thread::hardware_concurrency() rather than sysconf(_SC_NPROCESSORS_ONLN); that work only on unix systems

- Fix a typo error